### PR TITLE
Tune controller for moving to artifact origin

### DIFF
--- a/docker/subt_solution/Dockerfile
+++ b/docker/subt_solution/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update -qq \
         libspnav-dev \
         libusb-dev \
         lsb-release \
-        mercurial \
         python3-dbg \
         python3-empy \
         python3-numpy \
@@ -44,6 +43,7 @@ RUN /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu $(lsb
  && apt-get update -qq \
  && apt-get install -y -qq \
     python-catkin-tools \
+    python-rosdep \
     python-rosinstall \
     ros-melodic-desktop \
     ros-melodic-joystick-drivers \
@@ -94,8 +94,8 @@ RUN rosdep update
 
 RUN mkdir -p subt_solution/src \
  && cd subt_solution/src \
- && hg clone https://bitbucket.org/osrf/subt -b urban_circuit \
- && hg clone https://bitbucket.org/osrf/subt_seed
+ && git clone https://github.com/osrf/subt.git -b urban_circuit \
+ && git clone https://github.com/osrf/subt_seed.git
 
 WORKDIR /home/$USERNAME/subt_solution
 


### PR DESCRIPTION
It was observed that the robot could spin in place in the starting area and not move to the entrance.  This is mainly caused by slow pose responses from rosservice calls to the `pose_from_artifact_origin` service, which occurs when the system is under heavy load. Because the cmd vel persists on the simulation end, the slow pose updates cause the robot rotation to overshoot . When that happens, the current behavior is to to just keep turning in the same direction until it's within the the desired yaw angle threshold.

The main change in this PR is that the vel commands are now proportional. If the robot overshoots when turning, it'll correct itself by rotating the other direction.

Also fixed Dockerfile